### PR TITLE
Lab4 ex2 egor767

### DIFF
--- a/SpaceBattle.Lib/Commands/MacroLongOperation.cs
+++ b/SpaceBattle.Lib/Commands/MacroLongOperation.cs
@@ -1,0 +1,29 @@
+using Hwdtech;
+using Hwdtech.Ioc;
+
+namespace SpaceBattle.Lib;
+
+public class MacroLongOperation : ICommand
+{
+    private string _dependency;
+    private IUObject _obj;
+
+    public MacroLongOperation(string dependency, IUObject obj)
+    {
+        _dependency = dependency;
+        _obj = obj;
+    }
+
+    public void Execute()
+    {
+        var mc = IoC.Resolve<ICommand>("Create.LongMacro", _dependency, _obj);
+        mc.Execute();
+
+        var LongOperatin = IoC.Resolve<ICommand>("Game.Command.LongOperation", mc);
+        LongOperatin.Execute();
+        
+        var QueueCommand = IoC.Resolve<ICommand>("Game.Queue.Push", LongOperatin);
+        QueueCommand.Execute();
+    }
+}
+

--- a/SpaceBattle.Tests/CommandTests/MacroLongOperationTests/MacroLongOperationTests.cs
+++ b/SpaceBattle.Tests/CommandTests/MacroLongOperationTests/MacroLongOperationTests.cs
@@ -1,0 +1,44 @@
+using SpaceBattle.Lib;
+using TechTalk.SpecFlow;
+using Moq;
+using Hwdtech;
+using Hwdtech.Ioc;
+
+namespace SpaceBattle.Tests;
+
+public class MacroLongOperationTests
+{
+    private Mock<SpaceBattle.Lib.ICommand> _MoqCommand;
+    private Mock<IUObject> _MoqObj;
+    private string _dependency;
+
+    public MacroLongOperationTests()
+    {
+        _MoqCommand = new Mock<SpaceBattle.Lib.ICommand>();
+        _MoqObj = new Mock<IUObject>();
+
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+
+        var MoqDelegate = new Mock<Func<object[], object>>();
+
+        MoqDelegate.Setup(i => i(It.IsAny<object[]>())).Returns(_MoqCommand.Object);
+
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Create.LongMacro", (object[] args) => _MoqCommand.Object).Execute();
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Game.Command.LongOperation", (object[] args) => _MoqCommand.Object).Execute();
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Game.Queue.Push", (object[] args) => _MoqCommand.Object).Execute();
+    }
+
+    [Fact]
+    public void CreateMacroLongOperationSuccess()
+    {       
+        _dependency = "SomeDependency";
+
+        _MoqCommand.Setup(i => i.Execute()).Verifiable();
+        var LongOperatin = new MacroLongOperation(_dependency, _MoqObj.Object);
+        LongOperatin.Execute();
+
+        _MoqCommand.Verify(i => i.Execute(), Times.Exactly(3));
+    }
+}
+

--- a/SpaceBattle.Tests/CommandTests/MacroLongOperationTests/MacroLongOperationTests.cs
+++ b/SpaceBattle.Tests/CommandTests/MacroLongOperationTests/MacroLongOperationTests.cs
@@ -16,13 +16,11 @@ public class MacroLongOperationTests
     {
         _MoqCommand = new Mock<SpaceBattle.Lib.ICommand>();
         _MoqObj = new Mock<IUObject>();
+        var MoqDelegate = new Mock<Func<object[], object>>();
+        MoqDelegate.Setup(i => i(It.IsAny<object[]>())).Returns(_MoqCommand.Object);
 
         new InitScopeBasedIoCImplementationCommand().Execute();
         IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
-
-        var MoqDelegate = new Mock<Func<object[], object>>();
-
-        MoqDelegate.Setup(i => i(It.IsAny<object[]>())).Returns(_MoqCommand.Object);
 
         IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Create.LongMacro", (object[] args) => _MoqCommand.Object).Execute();
         IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Game.Command.LongOperation", (object[] args) => _MoqCommand.Object).Execute();
@@ -32,7 +30,7 @@ public class MacroLongOperationTests
     [Fact]
     public void CreateMacroLongOperationSuccess()
     {       
-        _dependency = "SomeDependency";
+        _dependency = "NewDependency";
 
         _MoqCommand.Setup(i => i.Execute()).Verifiable();
         var LongOperatin = new MacroLongOperation(_dependency, _MoqObj.Object);


### PR DESCRIPTION
ЛР№4. Макрокоманды.
Цель: научиться писать обобщенные стратегии разрешения зависимостей для IoC. 

Чтобы обеспечить выполнение SOLID принципов при выполнении операций над игровыми объектами, необходимо использовать макрокоманды - команды, единственной целью выполнения которых является выполнить последовательность других команд. 

2) Длительная операция.
Макрокоманды могут быть длительными операциями. Как, например, Move из лабораторной работы №2. Реализовать стратегию IoC, которая строит произвольную длительную операцию, получая на вход лишь имя зависимости длительной операции и объект, для которого это операция применяется. 
